### PR TITLE
Fix extraneous character in audio source tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
     </div>
     <div class="moon"></div>
     <audio id="space-audio" loop>
-        <source src="tough-cut.mp3" type="audio/mpeg">s
+        <source src="tough-cut.mp3" type="audio/mpeg">
         Your browser does not support the audio element.
     </audio>
     <script>


### PR DESCRIPTION
## Summary
- clean up `index.html` by removing an accidental character after the `<source>` element

## Testing
- `npm test` *(fails: missing `package.json`)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6840d18c3fe483278147681bc3afed3f